### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "tommusrhodus/Ebor-Framework",
+    "type": "wordpress-plugin",
+    "description": "The driving force behind TommusRhodus' Themes custom post types, meta boxes etc.",
+    "homepage": "https://www.tommusrhodus.com",
+    "license": "MIT",
+    "require": {
+        "composer/installers": "~1.0"
+    },
+    "authors": [
+        {
+            "name": "Tom Rhodes",
+            "homepage": "https://www.tommusrhodus.com",
+            "role": "Developer"
+        }
+    ]
+}

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 Plugin Name: Ebor Framework
 Plugin URI: http://www.tommusrhodus.com/ebor-framework/
 Description: Ebor Framework - The Driving Force Behind TommusRhodus Themes
-Version: 1.4.4
+Version: 1.5.0
 Author: Tom Rhodes
 Author URI: http://www.tommusrhodus.com/
 */	
@@ -13,7 +13,7 @@ Author URI: http://www.tommusrhodus.com/
  * Plugin definitions
  */
 define( 'EBOR_FRAMEWORK_PATH', trailingslashit(plugin_dir_path(__FILE__)) );
-define( 'EBOR_FRAMEWORK_VERSION', '1.4.4');
+define( 'EBOR_FRAMEWORK_VERSION', '1.5.0');
 
 /**
  * Styles & Scripts


### PR DESCRIPTION
WordPress plugins and themes can be managed via Composer. Adding this file facilitates that. So to the composer.json in a WP site you'd add:

```
{
  "type": "vcs",
  "url": "git@github.com:tommusrhodus/Ebor-Framework.git"
}
```

And then to your dependencies:

```
"tommusrhodus/Ebor-Framework": "^1.4.4",
```

Of course, this is also contingent on tagging this repo's releases on GitHub rather than just bumping the version number.

Edge case, but super useful, especially as frameworks for this mature, such as [Bedrock](https://github.com/roots/bedrock).