### PR TITLE
Fix updated function signature.

### DIFF
--- a/metaboxes/includes/types/CMB2_Type_Checkbox.php
+++ b/metaboxes/includes/types/CMB2_Type_Checkbox.php
@@ -32,7 +32,7 @@ class CMB2_Type_Checkbox extends CMB2_Type_Text {
 		$this->is_checked = $is_checked;
 	}
 
-	public function render() {
+	public function render( $args = array() ) {
 		$defaults = array(
 			'type'  => 'checkbox',
 			'class' => 'cmb2-option cmb2-list',

--- a/metaboxes/includes/types/CMB2_Type_Colorpicker.php
+++ b/metaboxes/includes/types/CMB2_Type_Colorpicker.php
@@ -32,7 +32,7 @@ class CMB2_Type_Colorpicker extends CMB2_Type_Text {
 		$this->value = $value ? $value : $this->value;
 	}
 
-	public function render() {
+	public function render( $args = array() ) {
 		$meta_value = $this->value ? $this->value : $this->field->escaped_value();
 
 		$hex_color = '(([a-fA-F0-9]){3}){1,2}$';

--- a/metaboxes/includes/types/CMB2_Type_Oembed.php
+++ b/metaboxes/includes/types/CMB2_Type_Oembed.php
@@ -12,7 +12,7 @@
  */
 class CMB2_Type_Oembed extends CMB2_Type_Text {
 
-	public function render() {
+	public function render( $args = array() ) {
 		$field = $this->field;
 
 		$meta_value = trim( $field->escaped_value() );


### PR DESCRIPTION
Fixes fatal error [introduced in PHP 7.2](https://bugs.php.net/bug.php?id=75590):

`PHP Fatal error:  Declaration of CMB2_Type_Oembed::render() must be compatible with CMB2_Type_Text::render($args = Array) in [...]/plugins/Ebor-Framework-master/metaboxes/includes/types/CMB2_Type_Oembed.php on line 0`

I have not verified if any of the other CMB2 class method signatures are mismatched.